### PR TITLE
mk: fix copying static library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ example: libsaveas.a
 	$(CC) example.c -o example -L. -I.. -lxcb -lxcb-image -lxcb-xkb -lxcb-keysyms -lxcb-cursor -lxcb-icccm -lsaveas
 
 install: libsaveas.a
-	rm -rf $(DESTDIR)$(PREFIX)/include/saveas
+	mkdir -p $(DESTDIR)$(PREFIX)/lib
 	mkdir -p $(DESTDIR)$(PREFIX)/include/saveas
-	cp -f saveas.h $(DESTDIR)$(PREFIX)/include/saveas
 	cp -f libsaveas.a $(DESTDIR)$(PREFIX)/lib
+	cp -f saveas.h $(DESTDIR)$(PREFIX)/include/saveas
 
 clean:
 	rm -f saveas.o libsaveas.a example


### PR DESCRIPTION
so, if you haven't noticed already; i do not create a directory for the static library. which means the library is literally copied as `/usr/lib`, a file called `lib`. maybe its sometimes important to add the `/` at the end of a directory to specify to the program that it is one.

how was this untested?